### PR TITLE
fix infinite newline character loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,27 +5,30 @@ const path = require('path')
 module.exports = robot => {
   robot.on('push', async context => {
     
-    const push = context.payload
+    let push = context.payload
 
-    const compare = await context.github.repos.compareCommits(context.repo({
+    let compare = await context.github.repos.compareCommits(context.repo({
       base: push.before,
       head: push.after
     }))
 
-    const branch = push.ref.replace('refs/heads/', '')
+    let branch = push.ref.replace('refs/heads/', '')
 
     return Promise.all(compare.data.files.map(async file => {
       if (path.extname(file.filename).toLowerCase() == '.md'){
-        const content = await context.github.repos.getContent(context.repo({
+        let content = await context.github.repos.getContent(context.repo({
           path: file.filename,
           ref:branch
         }))
 
-        const text = Buffer.from(content.data.content, 'base64').toString()
+        let text = Buffer.from(content.data.content, 'base64').toString()
 
+        // check if markdown includes the markdown-toc comment formatting
         if (text.includes('<!-- toc ')) {
           let config = await getConfig(context, 'toc.yml')
-          let updated = toc.insert(text, config)
+
+          // toc.insert() adds a trailing newline character we need to remove
+          let updated = toc.insert(text, config).replace(/\n$/, "")
           
           if (updated != text) {
             context.github.repos.updateFile(context.repo({
@@ -36,6 +39,7 @@ module.exports = robot => {
               branch
             }))
           }
+          
         }
       } 
     }))


### PR DESCRIPTION
This fixes a problem of looping infinite whitespace additions:

**What was happening**

* `toc.insert()` adds a newline character on the end of the generated text
*  the existing equality test `if(text != updated)` did not accommodate this

**What this PR does**

* trims last newline character from the generated text
* declares most `const` as `let`