### PR TITLE
end updated file in newline char

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,17 @@ module.exports = robot => {
         
         let text = Buffer.from(content.data.content, 'base64').toString()
 
+        if (text.slice(-1) !== '\n') {
+          text = text + '\n'
+        }
+
         // check if markdown includes the markdown-toc comment formatting
         if (text.includes('<!-- toc ')) {
           let config = await getConfig(context, 'toc.yml')
 
           // toc.insert() adds a trailing newline character we need to remove
-          let updated = toc.insert(text, config).replace(/\n$/, "")
-          
+          let updated = toc.insert(text, config)
+
           if (updated != text) {
             context.github.repos.updateFile(context.repo({
               path: file.filename,
@@ -48,6 +52,7 @@ module.exports = robot => {
               branch
             }))
           }
+          
           
         }
       } 


### PR DESCRIPTION
fixes #8 

This PR fixes the error which caused the updated markdown file to not end in a newline character