### PR TITLE
correct persisting newline error

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,15 @@ const path = require('path')
 
 module.exports = robot => {
   robot.on('push', async context => {
-    
     let push = context.payload
-    
-    let compare 
-    
-    if(push.before != '0000000000000000000000000000000000000000'){
+
+    let compare
+
+    if (push.before !== '0000000000000000000000000000000000000000') {
       compare = await context.github.repos.compareCommits(context.repo({
         base: push.before,
         head: push.after
-    }))
+      }))
     } else {
       compare = await context.github.repos.getCommit(context.repo({
         sha: push.after
@@ -23,25 +22,25 @@ module.exports = robot => {
     let branch = push.ref.replace('refs/heads/', '')
 
     return Promise.all(compare.data.files.map(async file => {
-      
-      if (path.extname(file.filename).toLowerCase() == '.md'){
+      if (path.extname(file.filename).toLowerCase() === '.md') {
         let content = await context.github.repos.getContent(context.repo({
           path: file.filename,
-          ref:branch
+          ref: branch
         }))
-        
-        let text = Buffer.from(content.data.content, 'base64').toString()
 
-        if (text.slice(-1) !== '\n') {
-          text = text + '\n'
-        }
+        let text = Buffer.from(content.data.content, 'base64').toString()
 
         // check if markdown includes the markdown-toc comment formatting
         if (text.includes('<!-- toc ')) {
           let config = await getConfig(context, 'toc.yml')
-
-          // toc.insert() adds a trailing newline character we need to remove
           let updated = toc.insert(text, config)
+
+          // toc.insert() adds a trailing newline character every time it is run
+          // we need to remove if the file already ends in one
+          // otherwise an infinite loop of newline commits can occur
+          if (text.slice(-1) === '\n') {
+            updated = updated.slice(0, -1)
+          }
 
           if (updated !== text) {
             context.github.repos.updateFile(context.repo({
@@ -52,11 +51,8 @@ module.exports = robot => {
               branch
             }))
           }
-          
-          
         }
-      } 
+      }
     }))
-
   })
 }


### PR DESCRIPTION
An earlier PR #9 sought to fix an error reported in #8. The previous fix did not completely address the problem.

An installation of the app reported files with an existing `newline` character were running through an infinite loop of commits adding a single additional newline character to markdown documents.

Investigation found that calling `toc.insert()` always adds a newline character to the end of the content. PR #9 sought to handle this by removing the trailing newline character (if it existed) before generating the new TOC (which would tack a newline character back on).

This PR corrects the observed (and replicated) infinite loop by:

* First retrieving the content of the modified markdown file and storing it in the `text` variable
* Second, generating the new content by calling `toc.insert(text, config)` and storing it in `updated`
* Third, checking to see if the source content `text` already had a trailing white space and removing the additional whitespace added to `updated` by `toc.insert()`