### PR TITLE
Check previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This app examines each push operation for markdown files formatted to use `markd
 
 ### Deploy and configure the app
 
-Follow the instructions in the [probot documentation](https://probot.github.io/docs/deployment/) to deploy your own version of `toc-me`
+The [probot deployment docs](https://probot.github.io/docs/deployment/) can be followed to deploy your own version of `toc-me`. You will need to define an additional environment variable `APP_NAME` and populate it with the exact name of your GitHub App.
 
 ### Configuring markdown files for TOC
 
@@ -42,7 +42,7 @@ append: 'this string will be appended to the end of the ToC'
 
 ## Contributing
 
-If you have suggestions for how toc-me could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how `toc-me` could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
 
 For more, check out the [Contributing Guide](CONTRIBUTING.md).
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,6 @@ module.exports = robot => {
             let config = await getConfig(context, 'toc.yml')
             let updated = toc.insert(text, config)
 
-            console.log("last updated: " + updated.slice(-1))
-
             // check to see if updated file ends in a newline
             // if not, add one
             if (updated.slice(-1) !== '\n') {

--- a/index.js
+++ b/index.js
@@ -39,10 +39,12 @@ module.exports = robot => {
             let config = await getConfig(context, 'toc.yml')
             let updated = toc.insert(text, config)
 
-            // check to see if original text already ended in a newline char
-            // if so remove the additional one added by markdown-toc
-            if (text.slice(-1) === '\n') {
-              updated = updated.slice(0, -1)
+            console.log("last updated: " + updated.slice(-1))
+
+            // check to see if updated file ends in a newline
+            // if not, add one
+            if (updated.slice(-1) !== '\n') {
+              updated = updated + '\n'
             }
 
             // update the file


### PR DESCRIPTION
per discussion in #9 this PR takes a slightly different approach to ensuring the resulting markdown ends in a new line. Changes include:

* running the app only if the commit was not created by the installation of `toc-me`
  * this makes sure `toc-me` will not modify its own commit and removes the previous comparison between existing text and that which is generated by `markdown-toc`
  * a new environment variable `APP_NAME` is introduced
* adding a newline character to the end of the `markdown-toc` generated text if not present